### PR TITLE
Relax Slim dependency

### DIFF
--- a/cells-slim.gemspec
+++ b/cells-slim.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "cells", ">= 4.0.1", "< 6.0.0"
-  spec.add_runtime_dependency "slim", "~> 3.0"
+  spec.add_runtime_dependency 'slim',  ['>= 3.0', '< 5.0']
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Similar to [slim-rails.gemspec](https://github.com/slim-template/slim-rails/blob/master/slim-rails.gemspec) we want to allow slim 4.x

Fixes #24